### PR TITLE
Updates to AgUnit based on StatLight breaking API changes.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/sl/StatLight"]
 	path = lib/sl/StatLight
-	url = http://github.com/sdekock/StatLight
+	url = http://github.com/staxmanade/StatLight

--- a/src/AgUnit.Runner.Resharper60.TaskRunner/UnitTestRunner/Silverlight/SilverlightResultsHandler.cs
+++ b/src/AgUnit.Runner.Resharper60.TaskRunner/UnitTestRunner/Silverlight/SilverlightResultsHandler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AgUnit.Runner.Resharper60.TaskRunner.UnitTestRunner.Silverlight.Execution;
-using EventAggregatorNet;
 using JetBrains.ReSharper.TaskRunnerFramework;
 using StatLight.Client.Harness.Events;
 using StatLight.Core.Events;


### PR DESCRIPTION
I've made a number of changes to StatLight that broke how AgUnit was interacting with it. However one change I made that should _help_ agunit is the InputOptions class. Now as statlight versions and adds options, I an put in sane defaults that should _hopfully_ keep AgUnit from having to update it's interaction with StatLight much.
