### PR TITLE
ReSharper 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ output/*
 resharper.log
 TestResults/
 ClientBin/*
+install/*.nupkg

--- a/install/AgUnit.nuspec
+++ b/install/AgUnit.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>AgUnit</id>
+    <title></title>
+    <version>0.7.0</version>
+    <authors>Steven de Kock</authors>
+    <owners>Steven de Kock</owners>
+    <description>Run Silverlight unit tests, using StatLight</description>
+    <projectUrl>https://agunit.codeplex.com</projectUrl>
+    <licenseUrl>https://agunit.codeplex.com/license</licenseUrl>
+    <copyright>Copyright 2013 Steven de Kock</copyright>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <dependencies>
+      <dependency id="ReSharper" version="8.0" />
+    </dependencies>
+    <tags>resharper unittest silverlight statlight</tags>
+  </metadata>
+  <files>
+    <file src="..\output\AgUnit.Runner.ReSharper80.dll"
+          target="ReSharper\v8.0\plugins" />
+    <file src="..\output\AgUnit.Runner.ReSharper80.TaskRunner.dll"
+          target="ReSharper\v8.0\plugins" />
+    <file src="..\output\StatLight.Core.dll" target="ReSharper\v8.0\plugins" />
+    <file src="..\output\*.xap" target="ReSharper\v8.0\plugins" />
+  </files>
+</package>

--- a/src/AgUnit.Runner.Resharper61/Properties/ProjectInfo.cs
+++ b/src/AgUnit.Runner.Resharper61/Properties/ProjectInfo.cs
@@ -9,7 +9,7 @@ using JetBrains.Application.PluginSupport;
 [assembly: AssemblyDescription("AgUnit - http://agunit.codeplex.com")]
 [assembly: AssemblyCompany("AgUnit - http://agunit.codeplex.com")]
 [assembly: AssemblyProduct("AgUnit - http://agunit.codeplex.com")]
-[assembly: AssemblyCopyright("Copyright © AgUnit authors - http://agunit.codeplex.com 2012")]
+[assembly: AssemblyCopyright("Copyright © AgUnit authors - http://agunit.codeplex.com 2013")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -28,6 +28,6 @@ using JetBrains.Application.PluginSupport;
 
 // Plugin info for ReSharper
 
-[assembly: PluginTitle("AgUnit 0.7 for R# 7.1")]
-[assembly: PluginDescription("AgUnit 0.7 for R# 7.1 - http://agunit.codeplex.com")]
+[assembly: PluginTitle("AgUnit")]
+[assembly: PluginDescription("Unit test runner for SilverLight - http://agunit.codeplex.com")]
 [assembly: PluginVendor("AgUnit authors - http://agunit.codeplex.com")]

--- a/src/AgUnit.Runner.Resharper61/UnitTestFramework/ExtendedDebugTaskRunnerHostController.cs
+++ b/src/AgUnit.Runner.Resharper61/UnitTestFramework/ExtendedDebugTaskRunnerHostController.cs
@@ -5,8 +5,8 @@ using AgUnit.Runner.Resharper61.UnitTestFramework.SilverlightPlatform;
 using AgUnit.Runner.Resharper61.Util;
 using EnvDTE;
 using JetBrains.ReSharper.UnitTestExplorer;
-using JetBrains.ReSharper.UnitTestFramework.Strategy;
 #if RS80
+using JetBrains.ReSharper.UnitTestFramework.Strategy;
 using JetBrains.ReSharper.UnitTestExplorer.Manager;
 using util::JetBrains.Util.Logging;
 using util::JetBrains.Threading;

--- a/src/AgUnit.Runner.Resharper61/UnitTestFramework/Silverlight/SilverlightUnitTestElement.cs
+++ b/src/AgUnit.Runner.Resharper61/UnitTestFramework/Silverlight/SilverlightUnitTestElement.cs
@@ -5,7 +5,9 @@ using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.TaskRunnerFramework;
 using JetBrains.ReSharper.UnitTestFramework;
+#if RS80
 using JetBrains.ReSharper.UnitTestFramework.Strategy;
+#endif
 
 namespace AgUnit.Runner.Resharper61.UnitTestFramework.Silverlight
 {

--- a/src/AgUnit.Runner.Resharper61/UnitTestFramework/SilverlightPlatform/UnitTestLaunchExtensions.cs
+++ b/src/AgUnit.Runner.Resharper61/UnitTestFramework/SilverlightPlatform/UnitTestLaunchExtensions.cs
@@ -5,8 +5,8 @@ using AgUnit.Runner.Resharper61.Util;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.TaskRunnerFramework;
 using JetBrains.ReSharper.UnitTestExplorer;
-using JetBrains.ReSharper.UnitTestFramework.Strategy;
 #if RS80
+using JetBrains.ReSharper.UnitTestFramework.Strategy;
 using JetBrains.ReSharper.UnitTestExplorer.Launch;
 #endif
 using JetBrains.ReSharper.UnitTestFramework;


### PR DESCRIPTION
Very minor changes to get AgUnit working with ReSharper 8.
- Clean compile
- Added nuspec file for extension gallery
- Nuspec file not necessarily correct - missing icon, and took liberty of adding your name as author and owner :grinning: 
- Removed version info from plugin attributes. Didn't bump version number, since no changes made

Looks like it works nicely with a simple compile! Any chance of a new build and getting the extension uploaded to the gallery, please? Note that if you're building against 8.0.1 or 8.0.2 binaries, the package should take a dependency on ReSharper >= 8.0.1000 or 8.0.2000, or the binary references will fail at runtime.
