### PR TITLE
Chage StatLight reference to Ionic Zip Reduce to specific verision

### DIFF
--- a/src/AgUnit.Runner.Resharper80.TaskRunner/AgUnit.Runner.Resharper80.TaskRunner.csproj
+++ b/src/AgUnit.Runner.Resharper80.TaskRunner/AgUnit.Runner.Resharper80.TaskRunner.csproj
@@ -37,8 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ionic.Zip.Reduced">
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.0\SDK\Bin\Ionic.Zip.Reduced.dll</HintPath>
     </Reference>
     <Reference Include="JetBrains.Platform.ReSharper.Shell">
       <SpecificVersion>False</SpecificVersion>
@@ -56,9 +55,8 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="JetBrains.ReSharper.UnitTestRunner.NUnit">
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+    <Reference Include="JetBrains.ReSharper.UnitTestRunner.nUnit">
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.0\SDK\Bin\JetBrains.ReSharper.UnitTestRunner.nUnit.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/AgUnit.Runner.Resharper80.TaskRunner/AgUnit.Runner.Resharper80.TaskRunner.csproj
+++ b/src/AgUnit.Runner.Resharper80.TaskRunner/AgUnit.Runner.Resharper80.TaskRunner.csproj
@@ -40,23 +40,24 @@
       <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.0\SDK\Bin\Ionic.Zip.Reduced.dll</HintPath>
     </Reference>
     <Reference Include="JetBrains.Platform.ReSharper.Shell">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.Platform.ReSharper.Shell.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.Platform.ReSharper.Util">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.Platform.ReSharper.Util.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.TaskRunnerFramework">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.TaskRunnerFramework.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.UnitTestRunner.MSTest10">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.UnitTestRunner.MSTest10.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.UnitTestRunner.nUnit">
-      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.0\SDK\Bin\JetBrains.ReSharper.UnitTestRunner.nUnit.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.UnitTestRunner.nUnit.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/AgUnit.Runner.Resharper80/AgUnit.Runner.Resharper80.csproj
+++ b/src/AgUnit.Runner.Resharper80/AgUnit.Runner.Resharper80.csproj
@@ -40,77 +40,77 @@
       <SpecificVersion>False</SpecificVersion>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="JetBrains.Platform.ReSharper.ComponentModel">
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.Platform.ReSharper.ComponentModel.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="JetBrains.Platform.ReSharper.Metadata">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.Platform.ReSharper.Metadata.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.Platform.ReSharper.ProjectModel">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.Platform.ReSharper.ProjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.Platform.ReSharper.Shell">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.Platform.ReSharper.Shell.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.Platform.ReSharper.UI">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.Platform.ReSharper.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.Platform.ReSharper.Util">
-      <SpecificVersion>False</SpecificVersion>
-      <Aliases>util</Aliases>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.Platform.ReSharper.Util.dll</HintPath>
       <Private>False</Private>
+      <Aliases>util</Aliases>
     </Reference>
     <Reference Include="JetBrains.Platform.ReSharper.VisualStudio.Core">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.Platform.ReSharper.VisualStudio.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.Feature.Services">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.Feature.Services.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.Features.Shared">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.Features.Shared.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.Psi">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.Psi.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.Resources">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.Resources.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.TaskRunnerFramework">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.TaskRunnerFramework.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.UnitTestExplorer">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.UnitTestExplorer.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.UnitTestFramework">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.UnitTestFramework.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="JetBrains.ReSharper.UnitTestProvider.MSTest">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.UnitTestProvider.MSTest.dll</HintPath>
       <Private>False</Private>
       <Aliases>mstestlegacy</Aliases>
     </Reference>
     <Reference Include="JetBrains.ReSharper.UnitTestProvider.MSTest10">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.UnitTestProvider.MSTest10.dll</HintPath>
       <Private>False</Private>
       <Aliases>mstest10</Aliases>
     </Reference>
     <Reference Include="JetBrains.ReSharper.UnitTestRunner.MSTest10">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files (x86)\JetBrains\ReSharper\v8.2\Bin\JetBrains.ReSharper.UnitTestRunner.MSTest10.dll</HintPath>
       <Private>False</Private>
       <Aliases>mstest10</Aliases>
-    </Reference>
-    <Reference Include="JetBrains.Platform.ReSharper.ComponentModel">
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp">
       <Private>False</Private>


### PR DESCRIPTION
We started seeing an unhandled StatLight exception when attempting to run unit tests after an update to one of our project's binary references. 

It appears that version 1.9.1.8 of Ionic Zip Reduce which is included with ReShaper 8.2.2 was being loaded by the test runner. This version no longer contains an overload of the Read method on the ZipFile that takes a byte array. 

I changed the StatLight Core reference to specifically verison 1.9.1.5 of the Ionic Zip Reduce and set it to copy to output. Copying the contents of the output folder to the AgUnit folder in ReSharper Plugins directory seems to resolve the issue. The unhandled exception is no longer being thrown and and Process Explorer show that the 1.9.1.5 version of the Ionic Zip Reduce is being loaded.

I cannot explain why the update to one of our binary dependencies caused the unhandled exception when previously everything had been working fine. 

I look forward to your comments and or questions.
